### PR TITLE
separate init and docking

### DIFF
--- a/easydock/database.py
+++ b/easydock/database.py
@@ -89,28 +89,30 @@ def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', '
 def populate_setup_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', 'protein_setup')):
     conn = sqlite3.connect(db_fname)
     cur = conn.cursor()
-    d = deepcopy(args.__dict__)
-    values = [yaml.safe_dump(d), open(d['config']).read()]
-    update_sql_line = 'UPDATE setup SET yaml = ?, config = ?, '
+    
+    if cur.execute('SELECT config FROM setup').fetchone()[0] is None:
+        d = deepcopy(args.__dict__)
+        values = [yaml.safe_dump(d), open(d['config']).read()]
+        update_sql_line = 'UPDATE setup SET yaml = ?, config = ?, '
 
-    for v in args_to_save:
-        update_sql_line += v + ' = ?, '
-        if d[v] is not None:
-            values.append(open(d[v]).read())
-        else:
-            values.append(None)
+        for v in args_to_save:
+            update_sql_line += v + ' = ?, '
+            if d[v] is not None:
+                values.append(open(d[v]).read())
+            else:
+                values.append(None)
 
-    config_dict = yaml.safe_load(open(args.config))
-    for v in config_args_to_save:
-        update_sql_line += v + ' = ?, '
-        if config_dict[v] is not None:
-            values.append(open(config_dict[v]).read())
-        else:
-            values.append(None)
+        config_dict = yaml.safe_load(open(args.config))
+        for v in config_args_to_save:
+            update_sql_line += v + ' = ?, '
+            if config_dict[v] is not None:
+                values.append(open(config_dict[v]).read())
+            else:
+                values.append(None)
 
-    update_sql_line = update_sql_line[:-2] + ' WHERE config IS NULL'
-    cur.execute(update_sql_line, values)
-    conn.commit()
+        update_sql_line = update_sql_line[:-2] + ' WHERE config IS NULL'
+        cur.execute(update_sql_line, values)
+        conn.commit()
 
     conn.close()
 

--- a/easydock/make_clean_copy.py
+++ b/easydock/make_clean_copy.py
@@ -18,13 +18,11 @@ def create_clean_db_copy(db_fname, new_db_fname):
     conn.commit()
 
     res = cur.execute('SELECT * FROM setup')
-    removed_colnames = [d[0] for d in res.description if d[0] != 'yaml']
-    remove_col_sql_line = 'UPDATE setup SET '
-    for colnames in removed_colnames:
-        remove_col_sql_line += colnames + ' = NULL, '
-    remove_col_sql_line = remove_col_sql_line[:-2]
+    remove_colnames = [d[0] for d in res.description if d[0] != 'yaml']
+    sql = 'UPDATE setup SET ' +  ','.join(f'{item} = NULL' for item in remove_colnames)
+    sql = sql[:-2]
 
-    cur.execute(remove_col_sql_line)
+    cur.execute(sql)
     conn.commit()    
     cur.execute(f'VACUUM')
     conn.commit()

--- a/easydock/make_clean_copy.py
+++ b/easydock/make_clean_copy.py
@@ -1,0 +1,35 @@
+import sqlite3
+import os
+import argparse
+from easydock.preparation_for_docking import filepath_type
+
+class RawTextArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    pass
+
+def create_clean_db_copy(db_fname, new_db_fname):
+    os.system(f'cp {db_fname} {new_db_fname}')
+    conn = sqlite3.connect(new_db_fname)
+    cur = conn.cursor()
+    cur.execute(f"""UPDATE mols SET docking_score = NULL,
+                                    pdb_block = NULL,
+                                    mol_block = NULL,
+                                    dock_time = NULL,
+                                    time = NULL   """)
+    conn.commit()
+    cur.execute(f'VACUUM')
+    conn.commit()
+
+def main():
+    parser = argparse.ArgumentParser(description='Create a clean copy of docked database file to be reused for another program or protein target'
+                                     'The docking result of the database file is deleted, while the ligand preparation data is preserved',
+                                     formatter_class=RawTextArgumentDefaultsHelpFormatter)
+    parser.add_argument('-i', '--input', metavar='FILENAME', required=True, type=filepath_type,
+                        help='input db file that has been docked.')
+    parser.add_argument('-o', '--output', metavar='FILENAME', required=True, type=filepath_type,
+                        help='output SQLite DB with empty docking data that can be used to dock another protein or docking program.')
+
+    args = parser.parse_args()
+    create_clean_db_copy(args.input, args.output)
+
+if __name__ == '__main__':
+    main()

--- a/easydock/make_clean_copy.py
+++ b/easydock/make_clean_copy.py
@@ -1,13 +1,13 @@
 import sqlite3
-import os
 import argparse
+import shutil
 from easydock.preparation_for_docking import filepath_type
 
 class RawTextArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
     pass
 
 def create_clean_db_copy(db_fname, new_db_fname):
-    os.system(f'cp {db_fname} {new_db_fname}')
+    shutil.copyfile(db_fname, new_db_fname)
     conn = sqlite3.connect(new_db_fname)
     cur = conn.cursor()
     cur.execute(f"""UPDATE mols SET docking_score = NULL,

--- a/easydock/make_clean_copy.py
+++ b/easydock/make_clean_copy.py
@@ -16,8 +16,20 @@ def create_clean_db_copy(db_fname, new_db_fname):
                                     dock_time = NULL,
                                     time = NULL   """)
     conn.commit()
+
+    res = cur.execute('SELECT * FROM setup')
+    removed_colnames = [d[0] for d in res.description if d[0] != 'yaml']
+    remove_col_sql_line = 'UPDATE setup SET '
+    for colnames in removed_colnames:
+        remove_col_sql_line += colnames + ' = NULL, '
+    remove_col_sql_line = remove_col_sql_line[:-2]
+
+    cur.execute(remove_col_sql_line)
+    conn.commit()    
     cur.execute(f'VACUUM')
     conn.commit()
+
+    conn.close()
 
 def main():
     parser = argparse.ArgumentParser(description='Create a clean copy of docked database file to be reused for another program or protein target'

--- a/easydock/make_clean_copy.py
+++ b/easydock/make_clean_copy.py
@@ -20,7 +20,6 @@ def create_clean_db_copy(db_fname, new_db_fname):
     res = cur.execute('SELECT * FROM setup')
     remove_colnames = [d[0] for d in res.description if d[0] != 'yaml']
     sql = 'UPDATE setup SET ' +  ','.join(f'{item} = NULL' for item in remove_colnames)
-    sql = sql[:-2]
 
     cur.execute(sql)
     conn.commit()    

--- a/easydock/run_dock.py
+++ b/easydock/run_dock.py
@@ -133,8 +133,8 @@ def main():
                                      formatter_class=RawTextArgumentDefaultsHelpFormatter)
     input_output_group = parser.add_argument_group('Input/output files')
     init_group = parser.add_argument_group('Initialization parameters')
-    docking_group = parser.add_argument_group('docking parameter groups')
-    dock_n_init_group = parser.add_argument_group('Applicable for both docking and initialization parameters')
+    docking_group = parser.add_argument_group('Docking parameters')
+    common_argument_group = parser.add_argument_group('Common parameters for both docking and initialization)')
     
     input_output_group.add_argument('-i', '--input', metavar='FILENAME', required=False, type=filepath_type,
                         help='input file with molecules (SMI, SDF, SDF.GZ, PKL). Maybe be omitted if output DB was '
@@ -165,7 +165,7 @@ def main():
                         help='disable tautomerization of molecules during protonation (applicable to chemaxon only).')
     docking_group.add_argument('--sdf', action='store_true', default=False,
                         help='save best docked poses to SDF file with the same name as output DB.')
-    init_group.add_argument('--hostfile', metavar='FILENAME', required=False, type=filepath_type, default=None,
+    docking_group.add_argument('--hostfile', metavar='FILENAME', required=False, type=filepath_type, default=None,
                         help='text file with addresses of nodes of dask SSH cluster. The most typical, it can be '
                              'passed as $PBS_NODEFILE variable from inside a PBS script. The first line in this file '
                              'will be the address of the scheduler running on the standard port 8786. If omitted, '
@@ -179,9 +179,9 @@ def main():
                         help='prefix which will be added to all molecule names. This might be useful if multiple '
                              'repeated runs are made which will be analyzed together.')
     
-    dock_n_init_group.add_argument('-c', '--ncpu', default=1, type=cpu_type,
+    common_argument_group.add_argument('-c', '--ncpu', default=1, type=cpu_type,
                         help='number of cpus. This affects only docking on a single server.')
-    docking_group.add_argument('-v', '--verbose', action='store_true', default=False,
+    common_argument_group.add_argument('-v', '--verbose', action='store_true', default=False,
                         help='print progress to STDERR.')
     # parser.add_argument('--table_name', metavar='STRING', required=False, default='mols',
     #                     help='name of the main table in a database.')

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setuptools.setup(
     },
     entry_points={'console_scripts':
                       ['run_dock = easydock.run_dock:main',
-                       'get_sdf_from_dock_db = easydock.get_sdf_from_dock_db:main']}
+                       'get_sdf_from_dock_db = easydock.get_sdf_from_dock_db:main',
+                       'make_clean_copy = easydock.make_clean_copy:main']}
 )


### PR DESCRIPTION


As discussed, the initialisation and docking process will be separated to make it easier to implement future features. The steps for separating it and enable reusing database are shown below:

1. If a user submits an input file without config.yml only init step is occurred. Setup table is not populated.

> I only added setup['yaml'] so restore_setup_db function can still take in previous args in the initialisation step

2. If a user submits config.yml the setup table is populated and docking is started.

> The setup table content in docking will overwrite the content in initialisation step, by DELETE and INSERT command.
3. If a user submits both an input file and config.yml both steps occur sequentially.

4. Revise the section related to restoring settings from DB if it already exists. It is used for continuation of interrupted docking.

> Edited the DB to conditionally trigger setup['config'] related python lines.
5. Command line arguments should be separated into two (argparse) groups related to these two major steps.

> done with add_argument_group

6. Implement a script “make_clean_copy.py” which takes a DB and removes all data obtained during the docking step to get a DB copy with prepared structures only to be used for docking with another program. After removal of data use VACUUM query to reduce the DB size.

