### PR TITLE
accomodate sdf when init is interrupted

### DIFF
--- a/easydock/database.py
+++ b/easydock/database.py
@@ -252,7 +252,7 @@ def generate_init_data(mol_input: tuple[Chem.Mol, str], max_stereoisomers: int, 
             isomer_list.append(['smi', (mol_name, 0, smi_input, None)])
         return isomer_list
 
-
+from time import sleep
 def init_db(db_fname: str, input_fname: str, ncpu: int, max_stereoisomers=1, prefix: str=None):
     Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)
 
@@ -261,7 +261,7 @@ def init_db(db_fname: str, input_fname: str, ncpu: int, max_stereoisomers=1, pre
     cur = conn.cursor()
     mol_input = read_input.read_input(input_fname)
 
-    last_index = cur.execute('SELECT COUNT(smi_input) FROM mols WHERE (stereo_id = 0)').fetchone()[0]
+    last_index = cur.execute('SELECT COUNT(*) FROM mols WHERE (stereo_id = 0)').fetchone()[0]
     if last_index:        
         from itertools import islice
         mol_input = islice(mol_input, last_index, None)
@@ -275,14 +275,14 @@ def init_db(db_fname: str, input_fname: str, ncpu: int, max_stereoisomers=1, pre
                 data_smi.append(data)
             elif input_format == 'mol':
                 data_mol.append(data)
-
-        if i % 100 == 0:
+        
+        if i % 2 == 0:
             cur.executemany(f'INSERT INTO mols (id, stereo_id, smi_input, smi) VALUES(?, ?, ?, ?)', data_smi)
             cur.executemany(f'INSERT INTO mols (id, stereo_id, smi, source_mol_block_input, source_mol_block) VALUES(?, ?, ?, ?, ?)', data_mol)
             conn.commit()
             data_smi = []  # non 3D structures
             data_mol = []  # 3D structures
-
+            sleep(4)
     cur.executemany(f'INSERT INTO mols (id, stereo_id, smi_input, smi) VALUES(?, ?, ?, ?)', data_smi)
     cur.executemany(f'INSERT INTO mols (id, stereo_id, smi, source_mol_block_input, source_mol_block) VALUES(?, ?, ?, ?, ?)', data_mol)
     conn.commit()


### PR DESCRIPTION
When init_db is interrupted for sdf input, the `last_index` variable do not count the last molecule because it only counts the `smi_input` field. I simply ask the sql to count the row with all of the column