### PR TITLE
moldock change to raw_block

### DIFF
--- a/easydock/database.py
+++ b/easydock/database.py
@@ -173,15 +173,15 @@ def restore_setup_from_db(db_fname, tmpdir=None):
         try:
             vars_dict = get_variables(conn, 'database', ['raw_format'])
             raw_format = vars_dict['raw_format']
-        except KeyError:
+        except (KeyError, sqlite3.OperationalError):
             raw_format = DEFAULT_RAW_FORMAT
 
     d = yaml.safe_load(values['yaml'])
-    d['raw_format'] = raw_format
     try:
         c = yaml.safe_load(values['config'])
     except AttributeError:
         c = {}
+    c['raw_format'] = raw_format
 
     del values['yaml']
 

--- a/easydock/database.py
+++ b/easydock/database.py
@@ -32,7 +32,30 @@ from rdkit.Chem.EnumerateStereoisomers import EnumerateStereoisomers, StereoEnum
 from rdkit.Chem.SaltRemover import SaltRemover
 
 
-def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', 'protein_setup'), unique_smi=False):
+VALID_RAW_FORMATS = ('pdbqt', 'sdf', 'pdb', 'mol2')
+DEFAULT_RAW_FORMAT = 'pdbqt'
+
+
+def validate_config(config_fname):
+    """
+    Read and validate the config YAML file.
+    :param config_fname: path to YAML config file, or None
+    :return: dict of validated config values
+    :raises ValueError: if any value is invalid
+    """
+
+    with open(config_fname) as f:
+        config = yaml.safe_load(f)
+    raw_format = config.get('raw_format', DEFAULT_RAW_FORMAT) if config is not None else DEFAULT_RAW_FORMAT
+    if raw_format not in VALID_RAW_FORMATS:
+        raise ValueError(
+            f"Invalid raw_format '{raw_format}' in config. "
+            f"Must be one of: {VALID_RAW_FORMATS}"
+        )
+    return {'raw_format': raw_format}
+
+
+def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', 'protein_setup'), unique_smi=False, config_dict=None):
     """
     Create empty database structure and the setup table, which is filled with values. To setup table two fields are
     always stored: yaml file with all input args of the docking script and yaml file with docking config
@@ -59,7 +82,7 @@ def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', '
                      source_mol_block TEXT,
                      source_mol_block_protonated TEXT,
                      docking_score REAL,
-                     pdb_block TEXT,
+                     raw_block TEXT,
                      mol_block TEXT,
                      dock_time REAL,
                      time TEXT,
@@ -100,6 +123,8 @@ def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', '
 
         # create some tables separately to keep backward compatibility
         create_variables_table(conn)
+        raw_format = config_dict['raw_format'] if config_dict is not None else DEFAULT_RAW_FORMAT
+        set_variable(conn, 'database', 'raw_format', raw_format)
         create_plif_tables(conn)
 
 
@@ -145,8 +170,14 @@ def restore_setup_from_db(db_fname, tmpdir=None):
         colnames = [d[0] for d in res.description]
         values = [v for v in res][0]
         values = dict(zip(colnames, values))
+        try:
+            vars_dict = get_variables(conn, 'database', ['raw_format'])
+            raw_format = vars_dict['raw_format']
+        except KeyError:
+            raw_format = DEFAULT_RAW_FORMAT
 
     d = yaml.safe_load(values['yaml'])
+    d['raw_format'] = raw_format
     try:
         c = yaml.safe_load(values['config'])
     except AttributeError:
@@ -739,14 +770,25 @@ def get_mols(conn, mol_ids, field_name='mol_block', poses=None):
                              f'Allowed: mol_block, source_mol_block, smi. Supplied: {field_name}')
 
     cur = conn.cursor()
+    if poses != [1]:
+        try:
+            raw_format = get_variables(conn, 'database', ['raw_format'])['raw_format']
+        except (KeyError, sqlite3.OperationalError):
+            raw_format = DEFAULT_RAW_FORMAT
+        if raw_format != 'pdbqt':
+            raise ValueError(
+                f"Pose extraction is only supported for 'pdbqt' format, "
+                f"but raw_format='{raw_format}' is stored in the database."
+            )
+
     t = ''
     if poses != [1]:
-        t = ', pdb_block'
+        t = ', raw_block'
 
     sql = f'SELECT id, stereo_id, rowid, {field_name} {t} FROM mols WHERE id IN (?) AND {field_name} IS NOT NULL'
 
     mols = []
-    for items in select_from_db(cur, sql, mol_ids):   # mol_block/smi, rowid, pdb_block
+    for items in select_from_db(cur, sql, mol_ids):   # mol_block/smi, rowid, raw_block
         m0 = func(items[3])
         if m0:
             m0.SetIntProp('_easydock_rowid', items[2])
@@ -755,10 +797,10 @@ def get_mols(conn, mol_ids, field_name='mol_block', poses=None):
             if 1 in poses:
                 mols.append(m0)
             if poses != [1]:
-                pdb_block_list = items[4].strip().split('ENDMDL')
+                raw_block_list = items[4].strip().split('ENDMDL')
                 for i in [j for j in poses if j != 1]:
                     try:
-                        pose = pdb_block_list[i - 1]
+                        pose = raw_block_list[i - 1]
                         pose_mol_block = pdbqt2molblock(pose + 'ENDMDL\n', m0)
                         m = Chem.MolFromMolBlock(pose_mol_block)
                         m.SetProp('_Name', f'{items[0]}_{items[1]}')
@@ -766,7 +808,7 @@ def get_mols(conn, mol_ids, field_name='mol_block', poses=None):
                         m.SetIntProp('_easydock_pose', i)
                         mols.append(m)
                     except IndexError:
-                        logging.warning(f'Pose number {i} is not in the PDB block of {m0.GetProp("_Name")}. '
+                        logging.warning(f'Pose number {i} is not in the raw block of {m0.GetProp("_Name")}. '
                                         f'It will be skipped.')
     cur.close()
     return mols
@@ -860,6 +902,28 @@ def create_variables_table(conn):
         );
     """)
     conn.commit()
+
+
+def migrate_pdb_block_to_raw_block(db_fname):
+    """
+    Migrate an existing database from pdb_block to raw_block column name.
+    Also ensures raw_format='pdbqt' is set in the variables table.
+    Safe to run multiple times (idempotent).
+    """
+    with sqlite3.connect(db_fname, timeout=90) as conn:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(mols)")
+        columns = [row[1] for row in cur.fetchall()]
+        if 'pdb_block' in columns and 'raw_block' not in columns:
+            cur.execute("ALTER TABLE mols RENAME COLUMN pdb_block TO raw_block")
+            logging.info(f"Migrated: pdb_block -> raw_block in {db_fname}")
+        create_variables_table(conn)
+        try:
+            get_variables(conn, 'database', ['raw_format'])
+        except KeyError:
+            set_variable(conn, 'database', 'raw_format', DEFAULT_RAW_FORMAT)
+            logging.info(f"Added raw_format='{DEFAULT_RAW_FORMAT}' to variables in {db_fname}")
+
 
 
 def set_variable(conn, module: str, name: str, value):

--- a/easydock/database.py
+++ b/easydock/database.py
@@ -779,7 +779,7 @@ def get_mols(conn, mol_ids, field_name='mol_block', poses=None):
     if poses != [1]:
         try:
             raw_format = get_variables(conn, 'database', ['raw_format'])['raw_format']
-        except (KeyError, sqlite3.OperationalError):
+        except KeyError:
             raw_format = DEFAULT_RAW_FORMAT
         if raw_format != 'pdbqt':
             raise ValueError(

--- a/easydock/database.py
+++ b/easydock/database.py
@@ -32,13 +32,15 @@ from rdkit.Chem.EnumerateStereoisomers import EnumerateStereoisomers, StereoEnum
 from rdkit.Chem.SaltRemover import SaltRemover
 
 
-VALID_RAW_FORMATS = ('pdbqt', 'sdf', 'pdb', 'mol2')
+VALID_RAW_FORMATS = ('pdbqt',)
 DEFAULT_RAW_FORMAT = 'pdbqt'
 
 
 def validate_config(config_fname):
     """
-    Read and validate the config YAML file.
+    Read the YAML config file and validate supported fields.
+    Currently, validation is implemented only for the `raw_format` option.
+    Other config fields, if present, are not validated by this function.
     :param config_fname: path to YAML config file, or None
     :return: dict of validated config values
     :raises ValueError: if any value is invalid
@@ -55,7 +57,7 @@ def validate_config(config_fname):
     return {'raw_format': raw_format}
 
 
-def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', 'protein_setup'), unique_smi=False, config_dict=None):
+def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', 'protein_setup'), unique_smi=False):
     """
     Create empty database structure and the setup table, which is filled with values. To setup table two fields are
     always stored: yaml file with all input args of the docking script and yaml file with docking config
@@ -123,12 +125,11 @@ def create_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', '
 
         # create some tables separately to keep backward compatibility
         create_variables_table(conn)
-        raw_format = config_dict['raw_format'] if config_dict is not None else DEFAULT_RAW_FORMAT
-        set_variable(conn, 'database', 'raw_format', raw_format)
         create_plif_tables(conn)
 
 
 def populate_setup_db(db_fname, args, args_to_save=(), config_args_to_save=('protein', 'protein_setup')):
+    validated_args = validate_config(args.config)
     with sqlite3.connect(db_fname, timeout=90) as conn:
         cur = conn.cursor()
 
@@ -155,6 +156,8 @@ def populate_setup_db(db_fname, args, args_to_save=(), config_args_to_save=('pro
             update_sql_line = update_sql_line + ' WHERE config IS NULL'
             cur.execute(update_sql_line, values)
             conn.commit()
+        raw_format = validated_args['raw_format']
+        set_variable(conn, 'database', 'raw_format', raw_format)
 
 
 def restore_setup_from_db(db_fname, tmpdir=None):
@@ -173,7 +176,7 @@ def restore_setup_from_db(db_fname, tmpdir=None):
         try:
             vars_dict = get_variables(conn, 'database', ['raw_format'])
             raw_format = vars_dict['raw_format']
-        except (KeyError, sqlite3.OperationalError):
+        except KeyError:
             raw_format = DEFAULT_RAW_FORMAT
 
     d = yaml.safe_load(values['yaml'])
@@ -181,6 +184,9 @@ def restore_setup_from_db(db_fname, tmpdir=None):
         c = yaml.safe_load(values['config'])
     except AttributeError:
         c = {}
+
+    #add raw_format to restored config file explicitly to make it compatible
+    # with old databases created with config file without raw_format variable
     c['raw_format'] = raw_format
 
     del values['yaml']

--- a/easydock/get_sdf_from_dock_db.py
+++ b/easydock/get_sdf_from_dock_db.py
@@ -66,7 +66,7 @@ def main():
     if ext == 'sdf' and args.poses:
         try:
             docking_format = get_variables(conn, 'database', ['raw_format'])['raw_format']
-        except (KeyError, sqlite3.OperationalError):
+        except KeyError:
             docking_format = DEFAULT_RAW_FORMAT
         if docking_format != 'pdbqt':
             raise ValueError(

--- a/easydock/get_sdf_from_dock_db.py
+++ b/easydock/get_sdf_from_dock_db.py
@@ -8,6 +8,7 @@ import sys
 from rdkit import Chem
 
 from .preparation_for_docking import pdbqt2molblock
+from .database import get_variables, DEFAULT_RAW_FORMAT
 
 
 def main():
@@ -61,9 +62,19 @@ def main():
     else:
         raise ValueError('Wrong extension of output file. Only SDF and SMI are allowed.')
 
-    # add pdb_block field to retrieve poses, only if sdf file should be returned as output
-    if ext == 'sdf' and args.poses and 'pdb_block' not in args.fields:
-        args.fields.append('pdb_block')
+    # add raw_block field to retrieve poses, only if sdf file should be returned as output
+    if ext == 'sdf' and args.poses:
+        try:
+            docking_format = get_variables(conn, 'database', ['raw_format'])['raw_format']
+        except (KeyError, sqlite3.OperationalError):
+            docking_format = DEFAULT_RAW_FORMAT
+        if docking_format != 'pdbqt':
+            raise ValueError(
+                f"Pose extraction is only supported for 'pdbqt' format, "
+                f"but raw_format='{docking_format}' is stored in the database."
+            )
+        if 'raw_block' not in args.fields:
+            args.fields.append('raw_block')
 
     if args.fields:
         sql = f"SELECT {main_field}, {','.join(args.fields)} FROM mols WHERE mol_block IS NOT NULL"
@@ -117,21 +128,21 @@ def main():
                     else:
                         f.write(mol_block)  # write original mol block without pose id
                     for prop_name, prop_value in zip(args.fields, item[1:]):
-                        if prop_name != 'pdb_block':
+                        if prop_name != 'raw_block':
                             f.write(f'>  <{prop_name}>\n')
                             f.write(f'{str(prop_value)}\n\n')
                     f.write('$$$$\n')
                     if poses:
                         poses.remove(1)
                 if poses:
-                    pdb_block_list = item[1:][args.fields.index('pdb_block')].strip().split('ENDMDL')
-                    pdb_block_list = [q for q in pdb_block_list if q]
+                    raw_block_list = item[1:][args.fields.index('raw_block')].strip().split('ENDMDL')
+                    raw_block_list = [q for q in raw_block_list if q]
                     mol = Chem.MolFromMolBlock(mol_block)
                     for i in poses:  # 1-based
                         try:
-                            pose_mol_block = pdbqt2molblock(pdb_block_list[i-1] + 'ENDMDL\n', mol, mol_id + f'_{i}')
+                            pose_mol_block = pdbqt2molblock(raw_block_list[i-1] + 'ENDMDL\n', mol, mol_id + f'_{i}')
                         except IndexError:
-                            logging.warning(f'Pose number {i} is not in the PDB block of {mol_id}. '
+                            logging.warning(f'Pose number {i} is not in the raw block of {mol_id}. '
                                              f'It will be skipped.')
                             continue
                         if pose_mol_block:

--- a/easydock/gnina_dock.py
+++ b/easydock/gnina_dock.py
@@ -80,7 +80,7 @@ def mol_dock(mol, config, ring_sample=False):
             mol_block = pdbqt2molblock(pdbqt_out.split('MODEL')[1], mol, mol_id)
 
             dock_output = {'docking_score': score,
-                           'pdb_block': pdbqt_out,
+                           'raw_block': pdbqt_out,
                            'mol_block': mol_block}
 
             dock_output_conformer_list.append(dock_output)

--- a/easydock/qvina_dock.py
+++ b/easydock/qvina_dock.py
@@ -76,7 +76,7 @@ def mol_dock(mol, config, ring_sample=False):
             mol_block = pdbqt2molblock(pdbqt_out.split('MODEL')[1], mol, mol_id)
 
             dock_output = {'docking_score': score,
-                           'pdb_block': pdbqt_out,
+                           'raw_block': pdbqt_out,
                            'mol_block': mol_block}
 
             dock_output_conformer_list.append(dock_output)

--- a/easydock/run_dock.py
+++ b/easydock/run_dock.py
@@ -12,7 +12,7 @@ from multiprocessing import Pool
 from rdkit import Chem
 from rdkit.Chem.rdMolDescriptors import CalcNumRotatableBonds
 from easydock.database import create_db, restore_setup_from_db, init_db, check_db_status, update_db, save_sdf, select_mols_to_dock, \
-    add_protonation, populate_setup_db
+    add_protonation, populate_setup_db, validate_config
 from easydock.reporting import get_pipeline_statistics, write_stage_error_log, report_error_log_file
 from easydock.args_validation import protonation_type, protonation_programs, cpu_type, filepath_type
 
@@ -235,7 +235,12 @@ def main():
     try:
 
         if not os.path.isfile(args.output):
-            create_db(args.output, args)
+            config_dict = None
+            if args.config:
+                if not os.path.isfile(args.config):
+                    raise FileNotFoundError(f"Config file not found: {args.config}")
+                config_dict = validate_config(args.config)
+            create_db(args.output, args, config_dict=config_dict)
         else:
             args_dict, tmpfiles = restore_setup_from_db(args.output, args.tmpdir)
             # this will ignore stored values of those args which were supplied via command line

--- a/easydock/run_dock.py
+++ b/easydock/run_dock.py
@@ -235,12 +235,7 @@ def main():
     try:
 
         if not os.path.isfile(args.output):
-            config_dict = None
-            if args.config:
-                if not os.path.isfile(args.config):
-                    raise FileNotFoundError(f"Config file not found: {args.config}")
-                config_dict = validate_config(args.config)
-            create_db(args.output, args, config_dict=config_dict)
+            create_db(args.output, args)
         else:
             args_dict, tmpfiles = restore_setup_from_db(args.output, args.tmpdir)
             # this will ignore stored values of those args which were supplied via command line

--- a/easydock/run_dock.py
+++ b/easydock/run_dock.py
@@ -12,7 +12,7 @@ from multiprocessing import Pool
 from rdkit import Chem
 from rdkit.Chem.rdMolDescriptors import CalcNumRotatableBonds
 from easydock.database import create_db, restore_setup_from_db, init_db, check_db_status, update_db, save_sdf, select_mols_to_dock, \
-    add_protonation, populate_setup_db, validate_config
+    add_protonation, populate_setup_db
 from easydock.reporting import get_pipeline_statistics, write_stage_error_log, report_error_log_file
 from easydock.args_validation import protonation_type, protonation_programs, cpu_type, filepath_type
 

--- a/easydock/vina_dock.py
+++ b/easydock/vina_dock.py
@@ -65,7 +65,7 @@ def mol_dock2(mol, protein, center, box_size, seed, exhaustiveness, n_poses, ncp
     mol_block = pdbqt2molblock(pdbqt_out.split('MODEL')[1], mol, mol_id)
 
     return mol_id, {'docking_score': score,
-                    'pdb_block': pdbqt_out,
+                    'raw_block': pdbqt_out,
                     'mol_block': mol_block}
 
 
@@ -121,7 +121,7 @@ def mol_dock(mol, config, ring_sample=False):
                     res = json.loads(res)
                     mol_block = pdbqt2molblock(res['poses'].split('MODEL')[1], mol, mol_id)
                     dock_output = {'docking_score': res['docking_score'],
-                                   'pdb_block': res['poses'],
+                                   'raw_block': res['poses'],
                                    'mol_block': mol_block}
                     
                     dock_output_conformer_list.append(dock_output)

--- a/easydock/vinagpu_dock.py
+++ b/easydock/vinagpu_dock.py
@@ -77,7 +77,7 @@ def mol_dock(mol, config, ring_sample=False):
             mol_block = pdbqt2molblock(pdbqt_out.split('MODEL')[1], mol, mol_id)
 
             dock_output = {'docking_score': score,
-                           'pdb_block': pdbqt_out,
+                           'raw_block': pdbqt_out,
                            'mol_block': mol_block}
 
             dock_output_conformer_list.append(dock_output)


### PR DESCRIPTION
The pdb_block column in the mols table has been renamed to raw_block to better reflect that the stored format is not necessarily PDB. A new raw_format variable is now stored in the variables table to track which format is used. 